### PR TITLE
fix: pushing context updates

### DIFF
--- a/pg_client.go
+++ b/pg_client.go
@@ -8,15 +8,15 @@ import (
 	"strings"
 	"time"
 
-	"github.com/netcracker/qubership-core-lib-go/v3/utils"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/stdlib"
-	"github.com/netcracker/qubership-core-lib-go/v3/configloader"
 	dbaasbase "github.com/netcracker/qubership-core-lib-go-dbaas-base-client/v3"
 	"github.com/netcracker/qubership-core-lib-go-dbaas-base-client/v3/cache"
 	"github.com/netcracker/qubership-core-lib-go-dbaas-base-client/v3/model/rest"
 	"github.com/netcracker/qubership-core-lib-go-dbaas-postgres-client/v4/model"
+	"github.com/netcracker/qubership-core-lib-go/v3/configloader"
+	"github.com/netcracker/qubership-core-lib-go/v3/utils"
 	"github.com/uptrace/bun"
 	"github.com/uptrace/bun/dialect/pgdialect"
 	"github.com/uptrace/bun/migrate"
@@ -55,7 +55,7 @@ func (p *pgClientImpl) GetSqlDb(ctx context.Context) (*sql.DB, error) {
 		return nil, err
 	}
 	// check if valid
-	if pErr := pgDb.Ping(); pErr != nil {
+	if pErr := pgDb.PingContext(ctx); pErr != nil {
 		logger.Warnf("connection ping failed with err: %v. Deleting conn from cache and recreating connection", pErr)
 		p.postgresqlCache.Delete(key)
 		pgDb.Close()
@@ -64,7 +64,7 @@ func (p *pgClientImpl) GetSqlDb(ctx context.Context) (*sql.DB, error) {
 			return nil, err
 		}
 	}
-	if valid, vErr := p.isPasswordValid(pgDb); !valid && vErr == nil {
+	if valid, vErr := p.isPasswordValid(ctx, pgDb); !valid && vErr == nil {
 		logger.Info("authentication error, try to get new password")
 		connConfig, vErr := p.getPasswordAgain(ctx, classifier, p.params.BaseDbParams)
 		if vErr != nil {
@@ -139,8 +139,8 @@ func (p *pgClientImpl) createNewPgDb(ctx context.Context, classifier map[string]
 	}
 }
 
-func (p *pgClientImpl) isPasswordValid(pgDb *sql.DB) (bool, error) {
-	if _, err := pgDb.Exec("SELECT 1;"); err != nil {
+func (p *pgClientImpl) isPasswordValid(ctx context.Context, pgDb *sql.DB) (bool, error) {
+	if _, err := pgDb.ExecContext(ctx, "SELECT 1;"); err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
 			pgErrCode := pgErr.Code // Code: the SQLSTATE code for the error

--- a/pg_client_test.go
+++ b/pg_client_test.go
@@ -2,8 +2,10 @@ package pgdbaas
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -520,4 +522,91 @@ func prepareTestContainer(t *testing.T, ctx context.Context) testcontainers.Cont
 	require.NoError(t, err)
 
 	return pg
+}
+
+func (suite *DatabaseTestSuite) TestPgClient_ContextCancellationRecreatesPool() {
+	// blackhole server that will hang any connection attempts
+	blackholeListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(suite.T(), err)
+	defer blackholeListener.Close()
+	go func() {
+		for {
+			conn, err := blackholeListener.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				select {} // block forever
+			}(conn)
+		}
+	}()
+
+	logicalDb := new(LogicalDb)
+	require.NoError(suite.T(), json.Unmarshal(
+		pgDbaasResponseHandler(blackholeListener.Addr().String(), "any"),
+		logicalDb,
+	))
+	dbaasClient := &contextCancellationDbaasClient{logicalDb: logicalDb}
+
+	params := model.DbParams{Classifier: ServiceClassifier, BaseDbParams: rest.BaseDbParams{Role: "admin"}}
+	client := pgClientImpl{
+		params:          params,
+		postgresqlCache: &cache.DbaaSCache{LogicalDbCache: make(map[cache.Key]interface{})},
+		dbaasClient:     dbaasClient,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	// start DB creation in separate routine to not block the main thread
+	type result struct {
+		db  *sql.DB
+		err error
+	}
+	dbCreationResult := make(chan result, 1)
+	go func() {
+		db, err := client.GetSqlDb(ctx)
+		dbCreationResult <- result{db: db, err: err}
+	}()
+
+	select {
+	case res := <-dbCreationResult:
+		require.Error(suite.T(), res.err)
+		require.Contains(suite.T(), res.err.Error(), "context deadline exceeded")
+		require.Nil(suite.T(), res.db)
+		require.Equal(suite.T(), 2, dbaasClient.getOrCreateCalls)
+		require.ErrorIs(suite.T(), dbaasClient.recreationContextErr, context.DeadlineExceeded)
+	case <-time.After(1 * time.Second):
+		suite.T().Fatal("Pool recreation did not return")
+	}
+}
+
+type contextCancellationDbaasClient struct {
+	logicalDb            *LogicalDb
+	getOrCreateCalls     int
+	recreationContextErr error
+}
+
+func (c *contextCancellationDbaasClient) GetOrCreateDb(
+	ctx context.Context,
+	_ string,
+	_ map[string]interface{},
+	_ rest.BaseDbParams,
+) (*LogicalDb, error) {
+	c.getOrCreateCalls++
+	if c.getOrCreateCalls == 1 {
+		return c.logicalDb, nil
+	}
+	c.recreationContextErr = ctx.Err()
+	return nil, c.recreationContextErr
+}
+
+func (c *contextCancellationDbaasClient) GetConnection(
+	context.Context,
+	string,
+	map[string]interface{},
+	rest.BaseDbParams,
+) (map[string]interface{}, error) {
+	return nil, fmt.Errorf("unexpected GetConnection call")
 }


### PR DESCRIPTION
## Summary

- Backport #96 to the Cloud-Core 2026.2 maintenance line.

## Root cause

The SQL connection checks used `Ping` and `Exec`, so cancellation and deadlines from the caller's context were not propagated to those operations.

## Impact

Consumers on the `v4.3.x` line can receive the context-cancellation fix without adopting the newer `v4.4.x` dependency baseline.

## Validation

```
go test ./... -run TestSuite/TestPgClient_ContextCancellationRecreatesPool -count=1
```